### PR TITLE
Fix Android build settings for FishApp

### DIFF
--- a/FishApp/FishApp.csproj
+++ b/FishApp/FishApp.csproj
@@ -9,7 +9,7 @@
     <ApplicationTitle>FishApp</ApplicationTitle>
     <ApplicationId>com.example.fishapp</ApplicationId>
     <ApplicationIdGuid>00000000-0000-0000-0000-000000000001</ApplicationIdGuid>
-    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>18.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersioniOS>15.0</SupportedOSPlatformVersioniOS>
   </PropertyGroup>
   <ItemGroup>

--- a/FishApp/Platforms/Android/AndroidManifest.xml
+++ b/FishApp/Platforms/Android/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:allowBackup="true" android:label="FishApp" android:icon="@mipmap/appicon" />
+    <application android:allowBackup="true" android:label="FishApp" android:icon="@drawable/appicon" />
 </manifest>

--- a/FishApp/Platforms/Android/Resources/drawable/appicon.xml
+++ b/FishApp/Platforms/Android/Resources/drawable/appicon.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#1E88E5"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="0.9"
+        android:pathData="M16,60c8,-24 68,-24 76,0 -8,24 -68,24 -76,0z" />
+    <path
+        android:fillColor="#1E88E5"
+        android:pathData="M70,54a6,6 0 1,1 -12,0 6,6 0 1,1 12,0z" />
+</vector>


### PR DESCRIPTION
## Summary
- align the Android supported platform version with the project target
- update the manifest to use a drawable application icon and add a vector asset so builds succeed

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfa0a8bbf0833184121c3b9a1b2907