### PR TITLE
Update Android platform version and clean XAML includes

### DIFF
--- a/FishApp/FishApp.csproj
+++ b/FishApp/FishApp.csproj
@@ -9,13 +9,10 @@
     <ApplicationTitle>FishApp</ApplicationTitle>
     <ApplicationId>com.example.fishapp</ApplicationId>
     <ApplicationIdGuid>00000000-0000-0000-0000-000000000001</ApplicationIdGuid>
-    <SupportedOSPlatformVersion>18.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersioniOS>15.0</SupportedOSPlatformVersioniOS>
   </PropertyGroup>
   <ItemGroup>
-    <MauiXaml Include="App.xaml" />
-    <MauiXaml Include="AppShell.xaml" />
-    <MauiXaml Include="Views/*.xaml" />
     <None Update="Resources\Raw\*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- raise the Android `SupportedOSPlatformVersion` to 21 to meet the minimum deployment requirement
- remove explicit MAUI XAML includes so resources are only registered once

## Testing
- dotnet build *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa1b48d2c83319f18a83247ad8ef9