### PR TITLE
Fix Android platform version and icon reference

### DIFF
--- a/FishApp/FishApp.csproj
+++ b/FishApp/FishApp.csproj
@@ -10,6 +10,7 @@
     <ApplicationId>com.example.fishapp</ApplicationId>
     <ApplicationIdGuid>00000000-0000-0000-0000-000000000001</ApplicationIdGuid>
     <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+    <TargetPlatformVersion>34.0</TargetPlatformVersion>
     <SupportedOSPlatformVersioniOS>15.0</SupportedOSPlatformVersioniOS>
   </PropertyGroup>
   <ItemGroup>

--- a/FishApp/Platforms/Android/AndroidManifest.xml
+++ b/FishApp/Platforms/Android/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:allowBackup="true" android:label="FishApp" android:icon="@drawable/appicon" />
+    <application android:allowBackup="true" android:label="FishApp" android:icon="@mipmap/appicon" />
 </manifest>


### PR DESCRIPTION
## Summary
- raise the Android target platform version to 34.0 so it matches the supported platform version
- correct the Android manifest to reference the generated mipmap app icon

## Testing
- `dotnet build FishApp/FishApp.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa26b57ec83319cef0ab6b4ed5eed