### PR TITLE
Fix platform targets and provide Android app icon

### DIFF
--- a/FishApp/FishApp.csproj
+++ b/FishApp/FishApp.csproj
@@ -9,9 +9,16 @@
     <ApplicationTitle>FishApp</ApplicationTitle>
     <ApplicationId>com.example.fishapp</ApplicationId>
     <ApplicationIdGuid>00000000-0000-0000-0000-000000000001</ApplicationIdGuid>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
     <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
     <TargetPlatformVersion>34.0</TargetPlatformVersion>
-    <SupportedOSPlatformVersioniOS>15.0</SupportedOSPlatformVersioniOS>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
+    <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+    <TargetPlatformVersion>17.0</TargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Update="Resources\Raw\*.json">

--- a/FishApp/Platforms/Android/AndroidManifest.xml
+++ b/FishApp/Platforms/Android/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:allowBackup="true" android:label="FishApp" android:icon="@mipmap/appicon" />
+    <application android:allowBackup="true" android:label="FishApp" android:icon="@drawable/appicon" />
 </manifest>

--- a/FishApp/Platforms/Android/Resources/drawable/appicon.xml
+++ b/FishApp/Platforms/Android/Resources/drawable/appicon.xml
@@ -5,13 +5,12 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#1E88E5"
+        android:fillColor="#512BD4"
         android:pathData="M0,0h108v108h-108z" />
     <path
         android:fillColor="#FFFFFFFF"
-        android:fillAlpha="0.9"
-        android:pathData="M16,60c8,-24 68,-24 76,0 -8,24 -68,24 -76,0z" />
+        android:pathData="M28,32c0,-6.627 5.373,-12 12,-12h28c6.627,0 12,5.373 12,12v44H28V32z" />
     <path
-        android:fillColor="#1E88E5"
-        android:pathData="M70,54a6,6 0 1,1 -12,0 6,6 0 1,1 12,0z" />
+        android:fillColor="#512BD4"
+        android:pathData="M40,44h28v20H40z" />
 </vector>

--- a/FishApp/Platforms/Android/Resources/values/styles.xml
+++ b/FishApp/Platforms/Android/Resources/values/styles.xml
@@ -2,7 +2,7 @@
 <resources>
     <style name="Maui.SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowSplashScreenBackground">#1E88E5</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/appicon</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/appicon</item>
         <item name="android:windowSplashScreenIconBackgroundColor">#FFFFFF</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- scope the Android and iOS target platform settings to their respective frameworks
- point the Android manifest and splash configuration at a drawable-based icon
- add a simple vector drawable so Android always has an application icon

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfa32651fc8331b8e0f554d7caef89