### PR TITLE
Set Windows package type to MSIX

### DIFF
--- a/FishApp/FishApp.csproj
+++ b/FishApp/FishApp.csproj
@@ -30,6 +30,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>MSIX</WindowsPackageType>
   </PropertyGroup>
   <ItemGroup>
     <None Update="Resources\Raw\*.json">


### PR DESCRIPTION
## Summary
- set the Windows target configuration to package as MSIX when no AppxManifest is provided

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfab06ddf083318a02f4003d48c7dc